### PR TITLE
Add OUT_PATH to environment variable

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-sh -c "$JEST_CMD $* --ci --testLocationInResults --json --outputFile=${OUT_PATH}report.json" &> /dev/null
+sh -c "$JEST_CMD $* --ci --testLocationInResults --json --outputFile=report.json" &> /dev/null
 set -e
-sh -c "cat ${OUT_PATH}report.json | /usr/bin/jest-action"
+sh -c "$OUTPUT_CMD cat report.json | /usr/bin/jest-action"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-sh -c "$JEST_CMD $* --ci --testLocationInResults --json --outputFile=report.json" &> /dev/null
+sh -c "$JEST_CMD $* --ci --testLocationInResults --json --outputFile=${OUT_PATH}report.json" &> /dev/null
 set -e
-sh -c "cat report.json | /usr/bin/jest-action"
+sh -c "cat ${OUT_PATH}report.json | /usr/bin/jest-action"


### PR DESCRIPTION
Trying to make this awesome action work for me in a monorepo setup.  
I have to run Jest from within each `packages/package-i`; and I was able to do that by setting `JEST_CMD` to `cd packages/package-i ; jest`, but then the results.json cannot be found.  
I'm hoping this PR will enable me to achieve what I'm after by setting the out path